### PR TITLE
Colocando somente espaço da aba de espaço no perfil do agente.

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Traits/EntityAgentRelation.php
+++ b/src/protected/application/lib/MapasCulturais/Traits/EntityAgentRelation.php
@@ -105,7 +105,8 @@ trait EntityAgentRelation {
                     $groups[] = array(
                         'group'   => $groupEntitie->group,
                         'entitie' => $entitie->name,
-                        'url'     => $entitie->singleUrl
+                        'url'     => $entitie->singleUrl,
+                        'object_type'=> $groupEntitie->owner
                     );
                 }
             }

--- a/src/protected/application/lib/MapasCulturais/Traits/EntityAgentRelation.php
+++ b/src/protected/application/lib/MapasCulturais/Traits/EntityAgentRelation.php
@@ -102,6 +102,7 @@ trait EntityAgentRelation {
             if($group){
                 foreach ($group as $groupEntitie) {
                     $entitie = App::i()->repo($entitieType['object_type'])->find($groupEntitie->objectId);
+                    //ADICIONADO OBJECT_TYPE PARA SABER QUAL A INSTANCIA É O GRUPO
                     $groups[] = array(
                         'group'   => $groupEntitie->group,
                         'entitie' => $entitie->name,

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/list-relations.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/list-relations.php
@@ -1,5 +1,4 @@
 <?php
-
     $groups = $entities->getGroupRelationsAgent();
 
     if(is_array($groups) && count($groups) > 0): ?>


### PR DESCRIPTION
Responsáveis:  
@Junior-Shyko  @FernandaNascimento26 

Linked Issue:  
Close #257 

### Descrição

Foi constatado que na aba de espaço, estava vindo todos os relacionamentos de uma agente com as entidades, então, foi solicitado que somente mostrasse o relacionamento com o espaço, desconsiderando as outras entidades.

### Passos a passo para teste

Verificar os critérios de aceitação

### Observações

Alguns commits não tem o número da issue.

