### PR TITLE
Feature/remove obrigatoriedade descricao

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ private-files
 docker-data
 scripts/nohup.out
 docker-compose.prod.yml
+docker-compose.local.yml

--- a/src/protected/application/lib/MapasCulturais/Entities/Agent.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/Agent.php
@@ -284,10 +284,10 @@ class Agent extends \MapasCulturais\Entity
             'name' => [
                 'required' => \MapasCulturais\i::__('O nome do agente é obrigatório')
             ],
-            'shortDescription' => [
+           /* 'shortDescription' => [
                 'required' => \MapasCulturais\i::__('A descrição curta é obrigatória'),
                 'v::stringType()->length(0,2000)' => \MapasCulturais\i::__('A descrição curta deve ter no máximo 2000 caracteres')
-            ],
+            ],*/
             'type' => [
                 'required' => \MapasCulturais\i::__('O tipo do agente é obrigatório'),
             ]

--- a/src/protected/application/themes/BaseV1/layouts/parts/widget-areas.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/widget-areas.php
@@ -5,7 +5,7 @@ $areas = array_values($app->getRegisteredTaxonomy($entityClass, 'area')->restric
 sort($areas);
 ?>
 <div class="widget">
-    <h3> <span class="required"></span> <?php $this->dict('taxonomies:area: name') ?></h3>
+    <h3><?php $this->dict('taxonomies:area: name') ?></h3>
     <?php if($this->isEditable()): ?>
         <span id="term-area" class="js-editable-taxonomy" data-original-title="<?php $this->dict('taxonomies:area: name') ?>" data-emptytext="<?php $this->dict('taxonomies:area: select at least one') ?>" data-restrict="true" data-taxonomy="area"><?php echo implode('; ', $entity->terms['area'])?></span>
     <?php else: ?>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26  @ericsonmoreira 

Linked Issue:  
Close #361

### Descrição

Retirada a obrigatoriedade de preenchimento dos campos **Descrição** e **Área de Atuação** na página de cadastro do agente.

### Passos a passo para teste

1. Clicar na foto do Usuário que fica no menu superior.
2. Selecionar a opção **Meu Perfil**.
3. Clicar no botão **Editar** (parte superior direita).
4. Verificar se não existe mais o asterisco indicando obrigatoriedade dos campos **Descrição** e **Área de Atuação**.
4. Remover os valores preenchidos nos campos **Descrição** e **Área de Atuação**.
5. Clicar no botão **Salvar** (parte superior direita).
6. Verificar se as alterações foram salvas com sucesso.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
