### PR TITLE
Botão de atalho para a oportunidade no próprio card de inscrição 

### DIFF
--- a/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--item.php
+++ b/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--item.php
@@ -8,16 +8,23 @@ $url = $this->isEditable() ? $opportunity->editUrl : $opportunity->singleUrl;
 ?>
 <article class="objeto <?php if($avatar) echo 'has-avatar' ?>">
     <?php if($avatar): ?>
-        <img src="<?php echo $avatar->url?>" >
+    <img src="<?php echo $avatar->url?>">
     <?php endif; ?>
     <div class="entity-opportunity--content ">
         <a href="<?php echo $url ?>"><?php echo $opportunity->name ?></a>
         <?php if($opportunity->status == Opportunity::STATUS_DRAFT): ?>
-            <em><?php i::_e('(Rascunho)') ?></em>
+        <em><?php i::_e('(Rascunho)') ?></em>
         <?php endif; ?>
         <br>
         <div class="objeto-meta">
             <?php $this->part('singles/opportunity-about--registration-dates', ['entity' => $opportunity, 'disable_editable' => true]) ?>
         </div>
+        <?php if ($app->auth->isUserAuthenticated()): ?>
+        <button class="btn-access" style="float: left; margin-right: 12px;" title="Acessar inscrições">
+            <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+            <a style="color: white;" href="<? echo $url; ?> "> Acessar Inscrição</a>
+        </button>
+        <?php endif; ?>
+        <hr>
     </div>
-</article >
+</article>

--- a/src/protected/application/lib/modules/OpportunityPhases/Module.php
+++ b/src/protected/application/lib/modules/OpportunityPhases/Module.php
@@ -460,7 +460,7 @@ class Module extends \MapasCulturais\Module{
         });
 
         // desliga a edição do campo principal de data quando vendo uma fase
-        $app->hook('view.partial(singles/opportunity-about--registration-dates).params', function(&$params){
+        $app->hook('view.partial(singles/opportunity-about--registration-dates-link).params', function(&$params){
             $opportunity = self::getRequestedOpportunity();
             $base_opportunity = self::getBaseOpportunity();
 


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 

Linked Issue:  
[Repositório Saúde #156](https://github.com/EscolaDeSaudePublica/Saude/issues/156)

### Descrição
Foi inserido botão de atalho, com nome Acessar Inscrição , na listagem de oportunidades de um subprojeto para que assim o usuário possa verificar os detalhes de uma oportunidade. 

Foi inserido a chamada de um novo componente  campo principal de data para que o usuário possa acaessar as fases de uma oportunidade e esta nao se replique na listagem de oportunidades de um projeto que era a real atividade desta issue
### Passos a passo para teste

1. Acessar o menu de projetos
2. clicar no botão **Acessar Inscrição** para acessar a página principal da oportunidade
3. Se a oportunidade possuir mais de uma fase, licar no botão **Acessar**
4. Verificar se acessa a proxima oportunidade com sucesso


### Observações

ssário

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
