### PR TITLE
Inserção campo de busca de agente no próprio card de inscrição da oportunidade de um Subprojeto

### DIFF
--- a/src/protected/application/lib/modules/EntityOpportunities/assets/css/entity-opportunities.css
+++ b/src/protected/application/lib/modules/EntityOpportunities/assets/css/entity-opportunities.css
@@ -2,11 +2,12 @@
         float: left;
         display: inline;
         margin-bottom:-72px;
-        width: 62px;
+        /* width: 62px; */
     }
     
     #entity-opportunities .objeto {
-        min-height: 82px;
+        /* min-height: 82px; */
+        display: flex;
     }
 
     #entity-opportunities .objeto.has-avatar .entity-opportunity--content {
@@ -14,11 +15,36 @@
         display: inline-block;
     }   
     
-    #entity-opportunities .objeto.has-avatar .entity-opportunity--content {
-        margin-left: 82px
-    }
-    
-    #entity-opportunities .objeto .objeto-meta>div{
-        margin-right: 1em;
-        float:left;
-    }
+#entity-opportunities .objeto.has-avatar .entity-opportunity--content {
+    /* margin-left: 20px */
+}
+
+#entity-opportunities .objeto .objeto-meta>div{
+    margin-right: 1em;
+    /* float:left; */
+}
+.card-info-opportunity {
+    background: #E8E8E8;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+}
+.avatar-card-info-opportunity {
+    background: white;
+    border-radius: 50%;
+    padding: 3px;
+    height: 64px;
+    width: 64px;
+}
+.pad-left-10 {
+    margin-left: 2%;
+}
+.card-info-header {
+    display: flex;
+}
+.card-info-header span {
+    display: flex;
+    flex-direction: column;
+    margin-left: 1rem;
+}
+

--- a/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--item.php
+++ b/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--item.php
@@ -1,30 +1,74 @@
-<?php 
+<?php
+
 use MapasCulturais\i;
 use MapasCulturais\Entities\Opportunity;
 
+/**
+ * Adicionado essas dependências para o funcionamento do componente do angular para buscar o(s) agente(s)
+ */
+$this->bodyProperties['ng-app'] = "entity.app";
+$this->bodyProperties['ng-controller'] = "EntityController";
+
+$this->jsObject['angularAppDependencies'][] = 'entity.module.opportunity';
+$this->jsObject['angularAppDependencies'][] = 'ui.sortable';
+
+$this->addEntityToJs($opportunity);
+
+$this->addOpportunityToJs($opportunity);
+
+$this->addOpportunitySelectFieldsToJs($opportunity);
+
+if ($this->isEditable()) {
+    $this->addEntityTypesToJs($opportunity);
+    $this->addTaxonoyTermsToJs('tag');
+}
+
+$this->includeAngularEntityAssets($opportunity);
+
+
 $avatar = $opportunity->avatar ? $opportunity->avatar->transform('avatarSmall') : null;
-    
+
 $url = $this->isEditable() ? $opportunity->editUrl : $opportunity->singleUrl;
+// $entity = $app->repo('ProjectOpportunity')->find();
+
 ?>
-<article class="objeto <?php if($avatar) echo 'has-avatar' ?>">
-    <?php if($avatar): ?>
-    <img src="<?php echo $avatar->url?>">
-    <?php endif; ?>
-    <div class="entity-opportunity--content ">
-        <a href="<?php echo $url ?>"><?php echo $opportunity->name ?></a>
-        <?php if($opportunity->status == Opportunity::STATUS_DRAFT): ?>
-        <em><?php i::_e('(Rascunho)') ?></em>
+<article class="objeto card-info-opportunity" ng-controller="OpportunityController">
+
+    <div class="card-info-header">
+        <?php if ($avatar) : ?>
+            <img src="<?php echo $avatar->url ?>" class="avatar-card-info-opportunity">
+        <?php else : ?>
+            <img src="<?php $this->asset('img/avatar--opportunity.png'); ?>" alt=""  class="avatar-card-info-opportunity" />
         <?php endif; ?>
-        <br>
-        <div class="objeto-meta">
+
+        <span>
+            <a href="<?php echo $url ?>"><?php echo $opportunity->name ?></a>
             <?php $this->part('singles/opportunity-about--registration-dates', ['entity' => $opportunity, 'disable_editable' => true]) ?>
-        </div>
-        <?php if ($app->auth->isUserAuthenticated()): ?>
-        <button class="btn-access" style="float: left; margin-right: 12px;" title="Acessar inscrições">
-            <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-            <a style="color: white;" href="<? echo $url; ?> "> Acessar Inscrição</a>
-        </button>
-        <?php endif; ?>
-        <hr>
+        </span>
     </div>
+    <div class="card-info-content">
+        <?php //if ($opportunity->status == Opportunity::STATUS_DRAFT) : ?>
+            <em><?php //i::_e('(Rascunho)') ?></em>
+        <?php //endif; 
+        $this->part('singles/opportunity-registrations--form', ['entity' => $opportunity]) 
+        ?>
+
+    </div>
+
+    <!-- <div class="entity-opportunity--content pad-left-10">
+       
+        <div class="">
+           
+        </div>
+        <?php //if ($opportunity->status == Opportunity::STATUS_DRAFT) : ?>
+            <em><?php //i::_e('(Rascunho)') ?></em>
+        <?php //endif; ?>
+        <br>
+        <div>
+            <?php
+            //$this->part('singles/opportunity-registrations--form', ['entity' => $opportunity]) ?>
+        </div>
+    </div> -->
+
+
 </article>

--- a/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--tabs-single.php
+++ b/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--tabs-single.php
@@ -1,3 +1,11 @@
-<?php if($entity->opportunities && ($entity->useOpportunityTab !== 'false')): ?>
+<?php 
+// Para ocultar a aba oportunidade
+if($entity instanceof \MapasCulturais\Entities\Project) {
+    $entity->useOpportunityTab = 'false';
+}else {
+    $entity->useOpportunityTab = null;
+}
+
+if($entity->opportunities && ($entity->useOpportunityTab !== 'false')): ?>
     <li><a href="#entity-opportunities" rel='noopener noreferrer'><?php echo $entity->opportunityTabName ? $entity->opportunityTabName : \MapasCulturais\i::__("Oportunidades");?></a></li>
 <?php endif; ?>


### PR DESCRIPTION
Responsáveis:  
@Junior-Shyko 
@FernandaNascimento26 

Linked Issue:  
Close #363 

### Descrição

Foi adicionado no próprio card da inscrição na oportunidade de um subprojeto o campo para buscar e selecionar um agente já cadastrado conforme protótipo apresentado na Issue.

Foi adicionado responsividade ao card e retirada a aba de subprojetos de projetos


### Passos a passo para teste

Esse PR é um complemento do PR (165)  do tema Saude:

1. Tentar acessar os projetos pai através do Menu Superior 'Projetos'
2. Verificar se houve o redirecionamento para a página do Projeto Pai
3. Verificar se exibe a aba Inscrições e dentro dela contém os projetos filhos, suas oportunidades e card de isncrições (se esta possuir inscrição aberta)
4. Clicar no card, adicionar o agente que está se inscrevendo e clicar em fazer incrição; 
5. Verificar se segue o fluxo normal de inscrição (redireciona para a páina de oportunidade para que a inscrição seja finalizada);


### Observações
1. Foi necessário criar um PR no repositório do Tema Saude

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
