### PR TITLE
ajuste session save path docker logs

### DIFF
--- a/src/protected/application/lib/MapasCulturais/App.php
+++ b/src/protected/application/lib/MapasCulturais/App.php
@@ -197,9 +197,9 @@ class App extends \Slim\Slim{
             error_reporting(E_ALL ^ E_STRICT);
 
     
-        session_start();
-
         session_save_path(SESSIONS_SAVE_PATH);
+
+        session_start();
         
         if($config['app.offline']){
             $bypass_callable = $config['app.offlineBypassFunction'];


### PR DESCRIPTION
Responsáveis:  
@victorMagalhaesPacheco 

### Descrição

Descrever_o_que_é_o_PR

### Passos a passo para teste

Ao executar o docker compose com o comando 
`docker-compose -f docker-compose.local up`  o log registra sempre o warning da session

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [ ] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [ ] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
