### PR TITLE
saude/#197 selos e inscrições conflitos entity

### DIFF
--- a/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--item.php
+++ b/src/protected/application/lib/modules/EntityOpportunities/layouts/parts/entity-opportunities--item.php
@@ -12,7 +12,10 @@ $this->bodyProperties['ng-controller'] = "EntityController";
 $this->jsObject['angularAppDependencies'][] = 'entity.module.opportunity';
 $this->jsObject['angularAppDependencies'][] = 'ui.sortable';
 
-$this->addEntityToJs($opportunity);
+// Se a rora for diferente de edição, então passa a entidade opportunity, mas se for edição então pode ser o lançamento de selos, devido ao conflito do objectjs
+if ($this->controller->action != 'edit') {
+    $this->addEntityToJs($opportunity);
+}
 
 $this->addOpportunityToJs($opportunity);
 


### PR DESCRIPTION
Responsáveis:  
@victorMagalhaesPacheco 

Linked Issue:  
Close https://github.com/EscolaDeSaudePublica/Saude/issues/197

### Descrição

Devido a atualização do layout e componentes dos projetos, alguns métodos foram adicionados sobrescrevendo o da entidade principal. Por exemplo, o problema acontecia quando era editado o projeto e era lançado um novo selo, o mesmo buscava o selo da entidade do objectjs, e o mesmo sobrescrevia, entretanto se passar a entidade correta o componente de inscrição para de funcionar. A solução é verificar o tipo de ação, "edit" e aplicar a entidade correta.

### Passos a passo para teste

- Acessar qualquer projeto e editar o projeto para adicionar o selo, o mesmo deve ser vinculado com sucesso.
- Acessar a página de projetos com todas as oportunidades disponíveis e realizar a inscrição em qualquer oportunidade.

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
