### PR TITLE
#461 redirecionamento apos cadastro no id saude

### DIFF
--- a/src/protected/application/lib/MapasCulturais/AuthProviders/OpauthKeyCloak.php
+++ b/src/protected/application/lib/MapasCulturais/AuthProviders/OpauthKeyCloak.php
@@ -208,8 +208,8 @@ class OpauthKeyCloak extends \MapasCulturais\AuthProvider{
                 $response = $this->_getResponse();
                 $user = $this->createUser($response);
 
-                $profile = $user->profile;
-                $this->_setRedirectPath($this->onCreateRedirectUrl ? $this->onCreateRedirectUrl : $profile->editUrl);
+                
+                $this->lastRedirectPath();
             }
             $this->_setAuthenticatedUser($user);
             App::i()->applyHook('auth.successful');
@@ -221,7 +221,16 @@ class OpauthKeyCloak extends \MapasCulturais\AuthProvider{
         }
     }
 
+
+    //Método que pega a última URL antes de criar o login ou do usuário logar no mapa da saúde
+    public function lastRedirectPath(){
+        $path = $this->_setRedirectPath($_SESSION['UriHttpReferer']);
+        return $path;
+    }
+
     protected function _createUser($response) {
+        
+    
         $app = App::i();
 
         $app->disableAccessControl();
@@ -243,7 +252,7 @@ class OpauthKeyCloak extends \MapasCulturais\AuthProvider{
         $app->em->persist($user);
         // cria um agente do tipo user profile para o usuário criado acima
         $agent = new Entities\Agent($user);
-        $agent->status = 0;
+        $agent->status = 1;
 
         if(isset($response['auth']['raw']['name']) && isset($response['auth']['raw']['surname'])){
             $agent->name = $response['auth']['raw']['name'] . ' ' . $response['auth']['raw']['surname'];
@@ -278,5 +287,6 @@ class OpauthKeyCloak extends \MapasCulturais\AuthProvider{
         $this->_setRedirectPath($this->onCreateRedirectUrl ? $this->onCreateRedirectUrl : $agent->editUrl);
 
         return $user;
+        
     }
 }


### PR DESCRIPTION
Responsáveis:  
@lucastandy @victorMagalhaesPacheco 

Linked Issue:  
Close #461

### Descrição
Ao efetuar cadastro de login no ID Saúde redirecionar o usuário para a página em que estava ao invés da página de cadastro do perfil

Foi adicionado um método chamado "lastRedirectPath" no arquivo "OpauthCloak.php". Essa funcionalidade permite salvar a última URL antes da pessoa criar um login no id saúde. Após a criação do login, o usuário é redirecionado para a última URL salva.

### Passos a passo para teste

Passo1: A pessoa deve acessar uma oportunidade e depois clicar no botão "Fazer login";
Passo2: Na página do IDSaúde, o candidato deve preencher os campos do formulário "Registre-se" e depois clicar no botão "Cadastre-se";
Passo3: O usuário deve observar que foi redirecionado para a última página antes de criar o login no IDSaúde.

### Observações
* A funcionalidade também serve para usuário já cadastro;
* Realizar o mesmo teste acima utilizando a página "Agentes".


## Checklist para criação do PR

- [ x] Testes foram implementados (novos ou não)
- [ x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [ x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
