### PR TITLE
Atualização no ambiente de desenvolvimento do Mapa da Saúde

### DIFF
--- a/compose/entrypoint.sh
+++ b/compose/entrypoint.sh
@@ -26,9 +26,11 @@ $pdo->query("UPDATE permission_cache_pending SET status = 0;");
 '
 if ! cmp /var/www/version.txt /var/www/private-files/deployment-version >/dev/null 2>&1
 then
-    cd /var/www/scripts
-    ./deploy.sh
+    /var/www/scripts/deploy.sh
     cp /var/www/version.txt /var/www/private-files/deployment-version
+else
+    /var/www/scripts/db-update.sh
+    /var/www/scripts/mc-db-updates.sh
 fi
 
 chown -R www-data:www-data /var/www/html/assets /var/www/html/files /var/www/private-files

--- a/compose/local/config.local.php
+++ b/compose/local/config.local.php
@@ -11,7 +11,7 @@ return [
     'slim.log.enabled'      => true,
 
     // 'app.log.query'         => true,
-    'app.log.hook'          => 'panel',
+       'app.log.hook'          => true,
     // 'app.log.requestData'   => true,
     // 'app.log.translations'  => true,
     // 'app.log.apiCache'      => true,

--- a/dev-scripts/docker-compose.local.yml
+++ b/dev-scripts/docker-compose.local.yml
@@ -15,25 +15,32 @@ services:
       - ../docker-data/assets:/var/www/html/assets
       - ../docker-data/public-files:/var/www/html/files
       - ../docker-data/private-files:/var/www/private-files
-      - ../docker-data/pcache-cron.log:/var/www/scripts/nohup.out
       - ../tests:/var/www/tests
     links:
       - db
+      - redis
+  
     environment:
       # - DB_HOST=db
       # - DB_NAME=mapas
       # - DB_USER=mapas
       # - DB_PASS=mapas
 
+      - PENDING_PCACHE_RECREATION_INTERVAL=15
       - APP_LCODE=pt_BR,es_ES
-      - ACTIVE_THEME=SpCultura
+      - ACTIVE_THEME=Saude
       - APP_MODE=development
+      - REDIS_CACHE=redis
 
     depends_on:
       - db
-      
+      - redis
     stdin_open: true
     tty: true
+  
+  redis:
+    image: redis:5
+    command: --maxmemory 256Mb --maxmemory-policy allkeys-lru
       
   db:
     image: mdillon/postgis:10
@@ -44,6 +51,6 @@ services:
     ports:
       - "5470:5432"
     volumes:
-      - ../docker-data/postgres:/var/lib/postgresql/data
-      - ../db/schema.sql:/docker-entrypoint-initdb.d/0.schema.sql
-      - ../db/initial-data.sql:/docker-entrypoint-initdb.d/1.data.sql
+      - ../docker-data/db:/var/lib/postgresql/data
+    # - ../docker-data/postgres:/var/lib/postgresql
+      - ../compose/local/dump.sql:/docker-entrypoint-initdb.d/dump.sql


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26  @Junior-Shyko 

Linked Issue:  


### Descrição

Em pareamento com a equipe do Hacklab, ocorreu a atualização em alguns arquivos do Mapa da Saúde para que fossem exibidos os logs dos Hooks, bem como fosse utilizada a configuração de ambiente desenvolvida pelo Hacklab (contida no diretório dev-scripts)

Os arquivos alterados foram:

- **docker-compose** do dev-scripts; 
- **entrypoint.sh** do compose (Neste, foi adicionado a segunda parte da verificação de atualização para que o db-updates só seja executado se houver uma mudança de versão do banco);
- no **config.local** foi habilitado o log dos hooks (isto para o caso de rodar o ambiente com o ```./start-dev.sh```

### Passos a passo para teste

1 - Entrar no diretório ```mapadasaude/dev-scripts``` e executar o comando: ```./start-dev.sh``` ;
2 - Após o mapa subir, devem aparecer os logs de todos os hooks do Mapa; 
3 - Caso deseje executar um hook específico, deve acessar novamente o arquivo **config.local**  e na linha que contém: `app.log.hook  => true`, deverá substituir o **true** pelo nome que remeta ao seu hook (exemplo: `'app.log.hook'          => 'claim'` , apresentará apenas os hooks que contém claim);

### Observações



## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [ ] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
