### PR TITLE
#501 ajuste de redirecionamento com parametros idsaude

### DIFF
--- a/src/protected/application/lib/MapasCulturais/AuthProviders/OpauthKeyCloak.php
+++ b/src/protected/application/lib/MapasCulturais/AuthProviders/OpauthKeyCloak.php
@@ -94,7 +94,8 @@ class OpauthKeyCloak extends \MapasCulturais\AuthProvider{
         unset($_SESSION['opauth']);
     }
     private function getUriHttpReferer() {
-        return $_SERVER['HTTP_REFERER'];
+        $app = App::i();
+        return $app->request()->cookies('mapasculturais_user_nav_url');
     }
     public function _requireAuthentication() {
         $app = App::i();


### PR DESCRIPTION
Responsáveis:  
@lucastandy @FernandaNascimento26 @victorMagalhaesPacheco 

Linked Issue:  
Close #501

### Descrição

Resolve problema de redirecionamento após autenticação do idsaúde com parâmetro do angular ou simples

### Passos a passo para teste

1. Acessar qualquer página do mapas
2. Clicar em fazer login na parte superior direita
3. Ao realizar a autenticação no id saúde no retorno o mapas deve redirecionar para a ultima página de acesso sendo ela url simples, com ou sem query string e também com os parâmetros do angular 1

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
