### PR TITLE
#501 ajuste de redirecionamento da pagina inicial do mapa

### DIFF
--- a/src/protected/application/lib/MapasCulturais/AuthProviders/OpauthKeyCloak.php
+++ b/src/protected/application/lib/MapasCulturais/AuthProviders/OpauthKeyCloak.php
@@ -95,7 +95,13 @@ class OpauthKeyCloak extends \MapasCulturais\AuthProvider{
     }
     private function getUriHttpReferer() {
         $app = App::i();
-        return $app->request()->cookies('mapasculturais_user_nav_url');
+        $caminho = $app->request()->cookies('mapasculturais_user_nav_url');
+        if(($_SERVER['HTTP_REFERER']==$app->createUrl('site', 'search')) and (isset($caminho))){
+            $path = $app->request()->cookies('mapasculturais_user_nav_url');
+        }else{
+            $path = $_SERVER['HTTP_REFERER'];
+        }
+        return $path;
     }
     public function _requireAuthentication() {
         $app = App::i();


### PR DESCRIPTION
Responsáveis:  
@lucastandy @FernandaNascimento26 @victorMagalhaesPacheco 

Linked Issue:  
Close #501

### Descrição

Resolve problema de redirecionamento para a página inicial do mapa após autenticação do idsaúde

### Passos a passo para teste

1. Acessar a página inicial do mapa
2. Clicar em fazer login na parte superior direita
3. Ao realizar a autenticação no id saúde no retorno o mapas deve redirecionar para a página inicial

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
