### PR TITLE
Adicionando um hook para o novo botão de salvar inscrição

### DIFF
--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/control--edit-buttons.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/control--edit-buttons.php
@@ -21,7 +21,7 @@
     <?php endif; ?>
 
 <?php elseif($this->controller->id === 'registration'): ?>
-    <a class="btn btn-primary js-submit-button" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Salvar");?></a>
+    <a class="btn btn-primary js-submit-button registration-disable-save-button-up" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Salvar");?></a>
 
 <?php else: ?>
     <a class="btn btn-primary js-submit-button" data-status="<?php echo $status_enabled ?>"><?php \MapasCulturais\i::_e("Salvar");?></a>

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-edit--send-button.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-edit--send-button.php
@@ -1,7 +1,8 @@
 <div class="registration-fieldset">
     <?php if($entity->opportunity->isRegistrationOpen()): ?>
         <p class="registration-help"><?php \MapasCulturais\i::_e("Certifique-se que você preencheu as informações corretamente antes de enviar sua inscrição.");?> <strong><?php \MapasCulturais\i::_e("Depois de enviada, não será mais possível editá-la.");?></strong></p>
-        <a class="btn btn-primary" ng-click="sendRegistration()" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Enviar inscrição");?></a>
+        <a class="btn btn-primary" ng-click="sendRegistration()" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Enviar inscrição");?></a> 
+        <?php $this->applyTemplateHook('registration-save-button','begin'); ?>
     <?php else: ?>
         <p class="registration-help">
             <strong>

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-edit--send-button.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/registration-edit--send-button.php
@@ -1,8 +1,7 @@
 <div class="registration-fieldset">
     <?php if($entity->opportunity->isRegistrationOpen()): ?>
         <p class="registration-help"><?php \MapasCulturais\i::_e("Certifique-se que você preencheu as informações corretamente antes de enviar sua inscrição.");?> <strong><?php \MapasCulturais\i::_e("Depois de enviada, não será mais possível editá-la.");?></strong></p>
-        <a class="btn btn-primary" ng-click="sendRegistration()" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Enviar inscrição");?></a> 
-        <?php $this->applyTemplateHook('registration-save-button','begin'); ?>
+        <a class="btn btn-primary" ng-click="sendRegistration()" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Enviar inscrição");?></a>
     <?php else: ?>
         <p class="registration-help">
             <strong>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 

Linked Issue:  
Issue encontra-se no tema: [#215](https://github.com/EscolaDeSaudePublica/Saude/issues/215)

### Descrição

Atualmente o botão salvar da inscrição encontra-se ao lado superior direito seguindo o padrão de layout do mapas culturais. Necessário realizar atualização do botão salvar para melhorar a usabilidade no processo de inscrição de uma oportunidade.

Para isso, foi necessário criar no core do Mapa um hook para adicionar este botão ao lado do botão de enviar inscrição.
Também foi adicionada uma classe do css no atual botão de salvar para que quando o hook que foi criado para acessr o botão seja acionado, o botão de cima fique desabilitado. 



## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
