### PR TITLE
Feature/multiple upload

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
@@ -28,7 +28,7 @@ class Registration extends EntityController {
 
             $registration = $this->requestedEntity;
 
-            if (!$registration) {
+            if (!$registration || !$registration->opportunity) {
                 return;
             }
             
@@ -87,11 +87,11 @@ class Registration extends EntityController {
                 'application/zip'
 
             ];
-            
+    
             foreach($registration->opportunity->registrationFileConfigurations as $rfc){
                 $fileGroup = new Definitions\FileGroup($rfc->fileGroupName, $mime_types, \MapasCulturais\i::__('O arquivo enviado não é um documento válido.'),  !$rfc->multiple, null, true);
                 $app->registerFileGroup('registration', $fileGroup);
-            }
+            }         
         });
 
         $app->hook('entity(Registration).file(rfc_<<*>>).insert:before', function() use ($app){
@@ -105,7 +105,12 @@ class Registration extends EntityController {
             $finfo = pathinfo($this->name);
             $hash = uniqid();
 
-            $this->name = $this->owner->number . ' - ' . $hash . ' - ' . preg_replace ('/[^\. \-\_\p{L}\p{N}]/u', '', $rfc->title) . '.' . $finfo['extension'];
+            if ($rfc->multiple && $this->description) {
+                $this->name = $this->owner->number . ' - ' . $hash . ' - ' . preg_replace ('/[^\. \-\_\p{L}\p{N}]/u', '', $rfc->title . ' - ' . $this->description) . '.' . $finfo['extension'];
+            } else {
+                $this->name = $this->owner->number . ' - ' . $hash . ' - ' . preg_replace ('/[^\. \-\_\p{L}\p{N}]/u', '', $rfc->title) . '.' . $finfo['extension'];
+            }
+
             $tmpFile = $this->tmpFile;
             $tmpFile['name'] = $this->name;
             $this->tmpFile = $tmpFile;

--- a/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
@@ -22,7 +22,16 @@ class Registration extends EntityController {
 
     function __construct() {
         $app = App::i();
-        $app->hook('POST(registration.upload):before', function() use($app) {
+       
+        $app->hook('<<*>>(registration.<<*>>):before', function() use($app) {
+       // $app->hook('POST(registration.upload):before', function() use($app) {
+
+            $registration = $this->requestedEntity;
+
+            if (!$registration) {
+                return;
+            }
+            
             $mime_types = [
                 'application/pdf',
                 'audio/.+',
@@ -78,10 +87,9 @@ class Registration extends EntityController {
                 'application/zip'
 
             ];
-            $registration = $this->requestedEntity;
+            
             foreach($registration->opportunity->registrationFileConfigurations as $rfc){
-
-                $fileGroup = new Definitions\FileGroup($rfc->fileGroupName, $mime_types, \MapasCulturais\i::__('O arquivo enviado não é um documento válido.'), true, null, true);
+                $fileGroup = new Definitions\FileGroup($rfc->fileGroupName, $mime_types, \MapasCulturais\i::__('O arquivo enviado não é um documento válido.'),  !$rfc->multiple, null, true);
                 $app->registerFileGroup('registration', $fileGroup);
             }
         });

--- a/src/protected/application/lib/MapasCulturais/Entities/File.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/File.php
@@ -284,8 +284,8 @@ abstract class File extends \MapasCulturais\Entity
         if($files){
             foreach($files as $file){
                 $registeredGroup = $app->getRegisteredFileGroup($file->owner->controllerId, $file->group);
-
-                if($registeredGroup && $registeredGroup->unique || $file->group === 'zipArchive' || strpos($file->group, 'rfc_') === 0){
+                
+                if($registeredGroup && $registeredGroup->unique || $file->group === 'zipArchive'){
                     $result[trim($file->group)] = $file;
                 }else{
                     if(!key_exists($file->group, $result))

--- a/src/protected/application/lib/MapasCulturais/Entities/RegistrationFileConfiguration.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/RegistrationFileConfiguration.php
@@ -81,6 +81,20 @@ class RegistrationFileConfiguration extends \MapasCulturais\Entity {
     */
     protected $__files;
 
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="metadata", type="array", nullable=false)
+     */
+    protected $_metadata = [];
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="multiple", type="boolean", nullable=true)
+     */
+    protected $multiple = false;
+
     static function getValidations() {
         $app = App::i();
         $validations = [
@@ -115,6 +129,14 @@ class RegistrationFileConfiguration extends \MapasCulturais\Entity {
         $this->categories = $value;
     }
 
+    public function setMetadata($value) {
+        $this->_metadata = (array) $value;
+    }
+
+    public function getMetadata() {
+        return (array) $this->_metadata;
+    }
+
     public function jsonSerialize() {
         return [
             'id' => $this->id,
@@ -125,7 +147,9 @@ class RegistrationFileConfiguration extends \MapasCulturais\Entity {
             'template' => $this->getFile('registrationFileTemplate'),
             'groupName' => $this->fileGroupName,
             'categories' => $this->categories,
-            'displayOrder' => $this->displayOrder
+            'displayOrder' => $this->displayOrder,
+            'metadata' => (object) $this->metadata,
+            'multiple' => (boolean) $this->multiple
         ];
     }
 

--- a/src/protected/application/lib/MapasCulturais/Storage/FileSystem.php
+++ b/src/protected/application/lib/MapasCulturais/Storage/FileSystem.php
@@ -194,11 +194,16 @@ class FileSystem extends \MapasCulturais\Storage{
             $file->delete(true);
         }
         \MapasCulturais\App::i()->em->refresh($entity);
-        $files = array_map(function($item){
-            if (is_array($item)) {
-                $item = $item[0];
+        $files = array_map(function($file){
+            if (is_array($file)) {
+                $files = array_map(function($item) {
+                    return '"'.$this->getPath($item).'"';
+                }, $file);
+                return implode(' ', $files);
+            } else {
+                return '"'.$this->getPath($file).'"';
             }
-            return '"'.$this->getPath($item).'"';
+            
         }, $entity->files);
 
 

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--fields.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/opportunity-registrations--fields.php
@@ -160,9 +160,12 @@ $app->applyHookBoundTo($this, 'opportunity.blockedFields', [$entity]);
                                 </div>
                                 <!-- edit-box to edit attachment -->
                                 <edit-box ng-if="data.entity.canUserModifyRegistrationFields" id="editbox-registration-files-{{field.id}}" position="left" title="<?php i::esc_attr_e("Editar Anexo");?>" cancel-label="<?php i::esc_attr_e("Cancelar");?>" submit-label="<?php i::esc_attr_e("Salvar");?>" close-on-cancel='true' on-cancel="cancelFileConfigurationEditBox" on-submit="editFileConfiguration" index="{{$index}}" spinner-condition="data.uploadSpinner">
-                                    <input type="text" ng-model="field.title" placeholder="<?php i::esc_attr_e("Nome do anexo");?>"/>
+                                <input type="text" ng-model="field.title" placeholder="<?php i::esc_attr_e("Nome do anexo");?>"/>
                                     <textarea ng-model="field.description" placeholder="<?php i::esc_attr_e("Descrição do anexo");?>"/></textarea>
-                                    <p><label><input type="checkbox" ng-model="field.required" ng-checked="field.required"> <?php i::_e("O envio deste anexo é obrigatório");?></label></p>
+                                    <p>
+                                        <label><input type="checkbox" ng-model="field.required" ng-checked="field.required"> <?php i::_e("O envio deste anexo é obrigatório");?></label><br>
+                                        <label><input type="checkbox" ng-model="field.multiple" ng-checked="field.multiple"> <?php i::_e("Aceitar multiplos arquivos");?></label>
+                                    </p>
 
                                     <p ng-if="data.categories.length > 1">
                                         <small><?php i::_e("Selecione em quais categorias este anexo é utilizado");?>:</small><br>

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -1380,6 +1380,11 @@ $$
             WHERE
                 object_type = 'MapasCulturais\Entities\EvaluationMethodConfiguration' AND
                 has_control IS false");
+    },
+    'alter table add registration_file_configuration metadata' => function() use($conn) {
+        $conn->executeQuery("ALTER TABLE registration_file_configuration ADD metadata TEXT;");
+    },
+    'alter table add registration_file_configuration multiple' => function() use($conn) {
+        $conn->executeQuery("ALTER TABLE registration_file_configuration ADD multiple BOOLEAN;");
     }
-
 ] + $updates ;


### PR DESCRIPTION
Responsáveis:  @victorMagalhaesPacheco 

Linked Issue:  #584

### Descrição

Implementa configuração na oportunidade de múltiplos uploads de arquivos nas inscrições

### Passos a passo para teste

1. Criar oportunidade
2. Criar campos de anexos e selecionar a opção "Aceitar múltiplos arquivos"
3. Realizar inscrição 
4. Anexar 1 ou N arquivos
5. Enviar inscrição
6. Como administrador baixar todos os arquivos com zip ou acessar inscrição e visualizar separadamente os arquivos anexados para cada campo de anexo

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
