### PR TITLE
add App use Seal

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Entities/Seal.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/Seal.php
@@ -4,6 +4,7 @@ namespace MapasCulturais\Entities;
 
 use Doctrine\ORM\Mapping as ORM;
 use MapasCulturais\Traits;
+use \MapasCulturais\App;
 
 /**
  * Seal


### PR DESCRIPTION
Responsáveis:  @victorMagalhaesPacheco 

### Descrição

Devido ao cherry pick realizado no commit para adicionar os hooks nas validações, é chamado a classe `App::i();` e não foi adicionado a importação da classe.
